### PR TITLE
Delete toc.yml which is not in use

### DIFF
--- a/officedocs-dev-ucwa-sdk-pr/toc.yml
+++ b/officedocs-dev-ucwa-sdk-pr/toc.yml
@@ -1,2 +1,0 @@
-- name: What is this API?
-  href: what-is-this-api.md


### PR DESCRIPTION
There are 2 `TOC` files(`TOC.md` and `toc.yml`) in the same folder, DocFX v2 only takes `TOC.md` into consideration.
And DocFX v3 only allows 1 `TOC` file in the same folder, this is blocking the migration to v3